### PR TITLE
Fix package.xml for rosdep install

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -42,7 +42,7 @@
   <build_depend>message_runtime</build_depend>
   <run_depend>message_runtime</run_depend>
 
-  <build_depend>GTSAM</build_depend>
-  <run_depend>GTSAM</run_depend>
+  <!--<build_depend>GTSAM</build_depend>
+  <run_depend>GTSAM</run_depend>-->
 
 </package>


### PR DESCRIPTION
When trying to install dependencies automatically via `rosdep install`, this package fails due to packages not being specified correctly according to the [`rosdistro` repository](https://github.com/ros/rosdistro). `GTSAM` is not available in these sources, therefore the dependency has been commented out. Dependency checking for GTSAM, PCL and OpenCV is handled via the `CMakeLists.txt` anyway.